### PR TITLE
Fixed deprecated core functions

### DIFF
--- a/djangode.js
+++ b/djangode.js
@@ -43,9 +43,9 @@ exports.serveFile = function(req, res, filename) {
         });
     }
     loadResponseData(function() {
-        res.sendHeader(status, headers);
+        res.writeHeader(status, headers);
         res.write(body, encoding);
-        res.close();
+        res.end();
     });
 }
 
@@ -56,22 +56,22 @@ exports.serve = function(app, port) {
 
 function respond(res, body, content_type, status) {
     content_type = content_type || 'text/html';
-    res.sendHeader(status || 200, {
+    res.writeHeader(status || 200, {
         'Content-Type': content_type  + '; charset=utf-8'
     });
     res.write(body, 'utf8');
-    res.close();
+    res.end();
 }
 exports.respond = respond;
 
 exports.redirect = redirect = function(res, location, status) {
     status = status || 301;
-    res.sendHeader(status || 200, {
+    res.writeHeader(status || 200, {
         'Content-Type': 'text/html; charset=utf-8',
         'Location': location
     });
     res.write('Redirecting...');
-    res.close();
+    res.end();
 }
 
 exports.extractPost = function(req, callback) {

--- a/djangode.js
+++ b/djangode.js
@@ -322,3 +322,4 @@ exports.mime = mime = {
         ".zip"   : "application/zip"
     }
 };
+

--- a/template/loader.js
+++ b/template/loader.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 var template_system = require('./template');
 
 var cache = {};
+var cacheMode = true;
 var template_path = '/tmp';
 
 
@@ -15,7 +16,7 @@ var template_path = '/tmp';
 var load = exports.load = function (name, callback) {
     if (!callback) { throw 'loader.load() must be called with a callback'; }
 
-    if (cache[name] != undefined) {
+    if (cacheMode && cache[name] != undefined) {
         callback(false, cache[name]);
     } else {
         fs.readFile(template_path + '/' + name, function (error, s) {
@@ -39,6 +40,10 @@ exports.load_and_render = function (name, context, callback) {
             template.render(context, callback);
         }
     });
+};
+
+exports.disableCache = function () {
+    cacheMode = false;
 };
 
 exports.flush = function () {

--- a/template/loader.js
+++ b/template/loader.js
@@ -19,9 +19,14 @@ var load = exports.load = function (name, callback) {
         callback(false, cache[name]);
     } else {
         fs.readFile(template_path + '/' + name, function (error, s) {
-            if (error) { callback(error); }
-            cache[name] = template_system.parse(s);
-            callback(false, cache[name]);
+            if (error) { 
+            	callback(error); 
+            }
+            else
+            {
+            	cache[name] = template_system.parse(s);
+            	callback(false, cache[name]);
+           	}
         });
     }
 };

--- a/template/template.js
+++ b/template/template.js
@@ -5,6 +5,7 @@ var sys = require('sys');
 var string_utils = require('../utils/string');
 var html = require('../utils/html');
 var iter = require('../utils/iter');
+var common = require('../utils/common');
 
 function normalize(value) {
     if (typeof value !== 'string') { return value; }
@@ -26,7 +27,7 @@ function Token(type, contents) {
     this.contents = contents;
 }
 
-process.mixin(Token.prototype, {
+common.extend(Token.prototype, {
     split_contents: function () {
         return string_utils.smart_split(this.contents);
     }
@@ -141,7 +142,7 @@ var FilterExpression = function (expression, constant) {
 
 };
 
-process.mixin(FilterExpression.prototype, {
+common.extend(FilterExpression.prototype, {
 
     consume: function (expression) {
         var m = filter_re.exec(expression);
@@ -239,7 +240,7 @@ function make_nodelist() {
     return node_list;
 }
 
-process.mixin(Parser.prototype, {
+common.extend(Parser.prototype, {
 
     parse: function () {
     
@@ -304,7 +305,7 @@ function Context(o) {
     this.filters = require('./template_defaults').filters;
 }
 
-process.mixin(Context.prototype, {
+common.extend(Context.prototype, {
     get: function (name) {
 
         if (typeof name !== 'string') { return name; }
@@ -358,7 +359,7 @@ function Template(input) {
     this.node_list = parser.parse();
 }
 
-process.mixin(Template.prototype, {
+common.extend(Template.prototype, {
     render: function (o, callback) {
 
         if (!callback) { throw 'template.render() must be called with a callback'; }

--- a/template/template.test.js
+++ b/template/template.test.js
@@ -1,6 +1,6 @@
 var sys = require('sys');
-process.mixin(GLOBAL, require('../utils/test').dsl);
-process.mixin(GLOBAL, require('./template'));
+common.extend(GLOBAL, require('../utils/test').dsl);
+common.extend(GLOBAL, require('./template'));
 
 testcase('Test tokenizer');
     test('sanity test', function () {

--- a/template/template_defaults.js
+++ b/template/template_defaults.js
@@ -6,8 +6,9 @@ var string_utils = require('../utils/string');
 var date_utils = require('../utils/date');
 var html = require('../utils/html');
 var iter = require('../utils/iter');
+var common = require('../utils/common');
 
-process.mixin(GLOBAL, require('../utils/tags'));
+common.extend(GLOBAL, require('../utils/tags'));
 
 /* TODO: Missing filters
 
@@ -325,7 +326,7 @@ var nodes = exports.nodes = {
             context.set('forloop', forloop);
 
             function inner(p, c, idx, list, next) {
-                process.mixin(forloop, {
+                common.extend(forloop, {
                     counter: idx + 1,
                     counter0: idx,
                     revcounter: list.length - idx,
@@ -544,7 +545,7 @@ var nodes = exports.nodes = {
 
     LoadNode: function (path, package) {
         return function (context, callback) {
-            process.mixin(context.filters, package.filters);
+            common.extend(context.filters, package.filters);
             callback(false, '');
         }
     },
@@ -816,7 +817,7 @@ var tags = exports.tags = {
         }
 
         var package = require(name);
-        process.mixin(parser.tags, package.tags);
+        common.extend(parser.tags, package.tags);
 
         return nodes.LoadNode(name, package);
     },

--- a/template/template_defaults.tags.test.js
+++ b/template/template_defaults.tags.test.js
@@ -2,8 +2,8 @@ var sys = require('sys');
 var fs = require('fs');
 var template = require('./template');
 
-process.mixin(GLOBAL, require('../utils/test').dsl);
-process.mixin(GLOBAL, require('./template_defaults'));
+common.extend(GLOBAL, require('../utils/test').dsl);
+common.extend(GLOBAL, require('./template_defaults'));
 
 function write_file(path, content) {
     var file = fs.openSync(path, process.O_WRONLY | process.O_TRUNC | process.O_CREAT, 0666);

--- a/template/template_defaults.test.js
+++ b/template/template_defaults.test.js
@@ -1,6 +1,6 @@
 var sys = require('sys');
-process.mixin(GLOBAL, require('../utils/test').dsl);
-process.mixin(GLOBAL, require('./template_defaults'));
+common.extend(GLOBAL, require('../utils/test').dsl);
+common.extend(GLOBAL, require('./template_defaults'));
 
 testcase('add')
     test('should add correctly', function () {

--- a/template_example.js
+++ b/template_example.js
@@ -57,7 +57,7 @@ var app = dj.makeApp([
             if (error) {
                 dj.default_show_500(req, res, error);
             } else {
-                dj.respond(res, result, 'text/plain');
+                dj.respond(res, result, 'text/html');
             }
         });
     }],

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,0 +1,9 @@
+function extend(a,b){
+    var prop;
+    for(prop in b) 
+        if (Object.prototype.hasOwnProperty.call(b,prop)) 
+            a[prop] = b[prop];
+    return a;
+} 
+
+exports.extend = extend;

--- a/utils/date.test.js
+++ b/utils/date.test.js
@@ -1,5 +1,5 @@
-process.mixin(GLOBAL, require('./test').dsl);
-process.mixin(GLOBAL, require('./date'));
+common.extend(GLOBAL, require('./test').dsl);
+common.extend(GLOBAL, require('./date'));
 var sys = require('sys');
 
 

--- a/utils/html.test.js
+++ b/utils/html.test.js
@@ -1,5 +1,5 @@
-process.mixin(GLOBAL, require('./test').dsl);
-process.mixin(GLOBAL, require('./html'));
+common.extend(GLOBAL, require('./test').dsl);
+common.extend(GLOBAL, require('./html'));
 
 testcase('tests for linebreaks()')
     test('should break lines into <p> and <br /> tags', function () {

--- a/utils/iter.test.js
+++ b/utils/iter.test.js
@@ -1,5 +1,5 @@
-process.mixin(GLOBAL, require('./test').dsl);
-process.mixin(GLOBAL, require('./iter'));
+common.extend(GLOBAL, require('./test').dsl);
+common.extend(GLOBAL, require('./iter'));
 
 var events = require('events');
 var sys = require('sys');

--- a/utils/string.test.js
+++ b/utils/string.test.js
@@ -1,7 +1,7 @@
 var sys = require('sys');
 
-process.mixin(GLOBAL, require('./test').dsl);
-process.mixin(GLOBAL, require('./string'));
+common.extend(GLOBAL, require('./test').dsl);
+common.extend(GLOBAL, require('./string'));
 
 testcase('string utility functions');
     test('smart_split should split correctly', function () {


### PR DESCRIPTION
response.close() should be response.end()
response.sendHeader() should be response.writeHeader()

mixin has been removed since they feel it isn't something for nodeJS core.
I added an extend function to a seperated utils file (based on https://github.com/simonw/djangode/issues/3#issuecomment-341139).

Awesome library if there's anything I can do more to contribute let me know!
