### PR TITLE
Remove process.mixin (which is deprecated/removed from Node)

### DIFF
--- a/djangode.js
+++ b/djangode.js
@@ -1,5 +1,5 @@
 var http = require('http'),
-    sys = require('sys'),
+    util = require('util'),
     fs = require('fs'),
     url = require('url'),
     querystring = require('querystring')
@@ -22,13 +22,14 @@ exports.serveFile = function(req, res, filename) {
             callback();
             return;
         }
-        sys.puts("loading " + filename + "...");
+        util.puts("loading " + filename + "...");
         fs.readFile(filename, encoding, function (error, data) {
             if (error) {
                 status = 404;
-                body = '404'
-                sys.puts("Error loading " + filename);
-                return callback();
+                body = '404';
+                util.puts("Error loading " + filename);
+                callback();
+                return;
             }
             body = data;
             headers = [
@@ -38,7 +39,7 @@ exports.serveFile = function(req, res, filename) {
                     : body.length
                 ]
             ];
-            sys.puts("static file " + filename + " loaded");
+            util.puts("static file " + filename + " loaded");
             callback();
         });
     }
@@ -47,12 +48,12 @@ exports.serveFile = function(req, res, filename) {
         res.write(body, encoding);
         res.close();
     });
-}
+};
 
 exports.serve = function(app, port) {
-    sys.puts('Server on http://127.0.0.1:' + port + '/');
+    util.puts('Server on http://127.0.0.1:' + port + '/');
     return http.createServer(app).listen(port);
-}
+};
 
 function respond(res, body, content_type, status) {
     content_type = content_type || 'text/html';
@@ -83,9 +84,9 @@ exports.extractPost = function(req, callback) {
     req.addListener('end', function() {
         callback(querystring.parse(url.parse('http://fake/?' + body).query));
     });
-}
+};
 
-var debuginfo = {}
+var debuginfo = {};
 exports.debuginfo = debuginfo;
 
 exports.makeApp = function(urls, options) {
@@ -104,10 +105,10 @@ exports.makeApp = function(urls, options) {
         var view = show_404;
         var args = [req, res];
         for (var pair, i = 0; pair = compiled[i]; i++) {
-            //sys.puts("Matching " + pair[0] + " against path " + path);
+            //util.puts("Matching " + pair[0] + " against path " + path);
             var match = pair[0](path);
             if (match) {
-                //sys.puts("  matched! " + match);
+                //util.puts("  matched! " + match);
                 // Add matched bits to args
                 match.slice(1).forEach(function(arg) {
                     args.push(arg);
@@ -122,7 +123,7 @@ exports.makeApp = function(urls, options) {
             debuginfo.last_e = e;
             show_500(req, res, e);
         }
-    }
+    };
     app.urls = {};
     urls.forEach(function (item) { app.urls[item[2]] = item[0]; });
     return app;
@@ -133,10 +134,10 @@ function default_show_404(req, res) {
         '<h1>404</h1>', 'text/html', 404
     );
 }
-exports.default_show_404 = default_show_404
+exports.default_show_404 = default_show_404;
 
 function default_show_500(req, res, e) {
-    var msg = ''
+    var msg = '';
     if ('stack' in e && 'type' in e) {
         msg = (
             '<p><strong>' + e.type + '</strong></p><pre>' + 
@@ -147,7 +148,7 @@ function default_show_500(req, res, e) {
     }
     respond(res, '<h1>500</h1>' + msg, 'text/html', 500);
 }
-exports.default_show_500 = default_show_500
+exports.default_show_500 = default_show_500;
 
 exports.mime = mime = {
     lookup : function(ext, fallback) {

--- a/template/loader.js
+++ b/template/loader.js
@@ -1,7 +1,6 @@
 /*jslint eqeqeq: true, undef: true, regexp: false */
 /*global require, process, exports, escape */
 
-var sys = require('sys');
 var fs = require('fs');
 var template_system = require('./template');
 

--- a/template/template.js
+++ b/template/template.js
@@ -5,6 +5,7 @@ var sys = require('sys');
 var string_utils = require('../utils/string');
 var html = require('../utils/html');
 var iter = require('../utils/iter');
+var mixin = require('../utils/mixin').mixin;
 
 function normalize(value) {
     if (typeof value !== 'string') { return value; }
@@ -26,7 +27,7 @@ function Token(type, contents) {
     this.contents = contents;
 }
 
-process.mixin(Token.prototype, {
+mixin(Token.prototype, {
     split_contents: function () {
         return string_utils.smart_split(this.contents);
     }
@@ -59,7 +60,7 @@ function tokenize(input) {
         var res = consume_until("{{", "{%");
 
         if (res[0]) { token_list.push( new Token('text', res[0]) ); }
-        
+
         if (res[1] === "{{") { return variable_tag; }
         if (res[1] === "{%") { return template_tag; }
         return undefined;
@@ -128,7 +129,7 @@ var FilterExpression = function (expression, constant) {
         if (parsed.constant !== undefined) { this.constant = normalize(parsed.constant); }
         if (parsed.variable !== undefined) { this.variable = normalize(parsed.variable); }
 
-        if (parsed.filter_name) { 
+        if (parsed.filter_name) {
             this.filter_list.push( this.make_filter_token(parsed) );
         }
 
@@ -141,7 +142,7 @@ var FilterExpression = function (expression, constant) {
 
 };
 
-process.mixin(FilterExpression.prototype, {
+mixin(FilterExpression.prototype, {
 
     consume: function (expression) {
         var m = filter_re.exec(expression);
@@ -239,10 +240,10 @@ function make_nodelist() {
     return node_list;
 }
 
-process.mixin(Parser.prototype, {
+mixin(Parser.prototype, {
 
     parse: function () {
-    
+
         var stoppers = Array.prototype.slice.apply(arguments);
         var node_list = make_nodelist();
         var token = this.token_list[0];
@@ -304,7 +305,7 @@ function Context(o) {
     this.filters = require('./template_defaults').filters;
 }
 
-process.mixin(Context.prototype, {
+mixin(Context.prototype, {
     get: function (name) {
 
         if (typeof name !== 'string') { return name; }
@@ -331,7 +332,7 @@ process.mixin(Context.prototype, {
 
                 if (typeof val === 'function') {
                     return val();
-                } else { 
+                } else {
                     return val;
                 }
             }
@@ -358,7 +359,7 @@ function Template(input) {
     this.node_list = parser.parse();
 }
 
-process.mixin(Template.prototype, {
+mixin(Template.prototype, {
     render: function (o, callback) {
 
         if (!callback) { throw 'template.render() must be called with a callback'; }

--- a/template/template.js
+++ b/template/template.js
@@ -1,7 +1,7 @@
 /*jslint laxbreak: true, eqeqeq: true, undef: true, regexp: false */
 /*global require, process, exports */
 
-var sys = require('sys');
+var util = require('util');
 var string_utils = require('../utils/string');
 var html = require('../utils/html');
 var iter = require('../utils/iter');
@@ -106,7 +106,7 @@ var FilterExpression = function (expression, constant) {
 
     var parsed = this.consume(expression);
 
-    //sys.debug(expression + ' => ' + sys.inspect( parsed ) );
+    //util.debug(expression + ' => ' + util.inspect( parsed ) );
 
     if (!parsed) {
         throw this.error(expression);
@@ -135,10 +135,10 @@ var FilterExpression = function (expression, constant) {
 
         parsed = this.consume(expression);
 
-        //sys.debug(expression + ' => ' + sys.inspect( parsed ) );
+        //util.debug(expression + ' => ' + util.inspect( parsed ) );
     }
 
-    //sys.debug(expression + ' => ' + sys.inspect( this ) );
+    //util.debug(expression + ' => ' + util.inspect( this ) );
 
 };
 
@@ -190,7 +190,7 @@ mixin(FilterExpression.prototype, {
                 return filter(p, arg, safety);
             } else {
                 // throw 'Cannot find filter';
-                sys.debug('Cannot find filter ' + c.name);
+                util.debug('Cannot find filter ' + c.name);
                 return p;
             }
         }, value);
@@ -249,17 +249,17 @@ mixin(Parser.prototype, {
         var token = this.token_list[0];
         var tag = null;
 
-        //sys.debug('' + this.indent++ + ':starting parsing with stoppers ' + stoppers.join(', '));
+        //util.debug('' + this.indent++ + ':starting parsing with stoppers ' + stoppers.join(', '));
 
         while (this.token_list.length) {
             if (stoppers.indexOf(this.token_list[0].type) > -1) {
-                //sys.debug('' + this.indent-- + ':parse done returning at ' + token[0] + ' (length: ' + node_list.length + ')');
+                //util.debug('' + this.indent-- + ':parse done returning at ' + token[0] + ' (length: ' + node_list.length + ')');
                 return node_list;
             }
 
             token = this.next_token();
 
-            //sys.debug('' + this.indent + ': ' + token);
+            //util.debug('' + this.indent + ': ' + token);
 
             tag = this.tags[token.type];
             if (tag && typeof tag === 'function') {
@@ -276,7 +276,7 @@ mixin(Parser.prototype, {
             throw new parser_error('Tag not found: ' + stoppers.join(', '));
         }
 
-        //sys.debug('' + this.indent-- + ':parse done returning end (length: ' + node_list.length + ')');
+        //util.debug('' + this.indent-- + ':parse done returning end (length: ' + node_list.length + ')');
 
         return node_list;
     },

--- a/template/template.test.js
+++ b/template/template.test.js
@@ -1,6 +1,7 @@
 var sys = require('sys');
-process.mixin(GLOBAL, require('../utils/test').dsl);
-process.mixin(GLOBAL, require('./template'));
+var mixin = require('../utils/mixin').mixin;
+mixin(GLOBAL, require('../utils/test').dsl);
+mixin(GLOBAL, require('./template'));
 
 testcase('Test tokenizer');
     test('sanity test', function () {
@@ -27,7 +28,7 @@ testcase('Test tokenizer');
 
 testcase('Filter Expression tests');
     test('should parse valid syntax', function () {
-        assertEquals( 
+        assertEquals(
             { variable: 'item', filter_list: [ { name: 'add' } ] },
             new FilterExpression("item|add")
         );

--- a/template/template.test.js
+++ b/template/template.test.js
@@ -1,4 +1,3 @@
-var sys = require('sys');
 var mixin = require('../utils/mixin').mixin;
 mixin(GLOBAL, require('../utils/test').dsl);
 mixin(GLOBAL, require('./template'));

--- a/template/template_defaults.js
+++ b/template/template_defaults.js
@@ -3,11 +3,12 @@
 
 var sys = require('sys');
 var string_utils = require('../utils/string');
+var mixin = require('../utils/mixin').mixin;
 var date_utils = require('../utils/date');
 var html = require('../utils/html');
 var iter = require('../utils/iter');
 
-process.mixin(GLOBAL, require('../utils/tags'));
+mixin(GLOBAL, require('../utils/tags'));
 
 /* TODO: Missing filters
 
@@ -28,7 +29,7 @@ Missing tags:
 NOTE:
     cycle tag does not support legacy syntax (row1,row2,row3)
     load takes a path - like require. Loaded module must expose tags and filters objects.
-    url tag relies on app being set in process.djangode_urls 
+    url tag relies on app being set in process.djangode_urls
 */
 
 var filters = exports.filters = {
@@ -198,7 +199,7 @@ var filters = exports.filters = {
     slice: function (value, arg) {
         if (!(value instanceof Array)) { return []; }
         var parts = (arg || '').split(/:/g);
-        
+
         if (parts[1] === '') {
             parts[1] = value.length;
         }
@@ -325,7 +326,7 @@ var nodes = exports.nodes = {
             context.set('forloop', forloop);
 
             function inner(p, c, idx, list, next) {
-                process.mixin(forloop, {
+                mixin(forloop, {
                     counter: idx + 1,
                     counter0: idx,
                     revcounter: list.length - idx,
@@ -501,7 +502,7 @@ var nodes = exports.nodes = {
     },
 
     FirstOfNode: function (/*...*/) {
-    
+
         var choices = Array.prototype.slice.apply(arguments);
 
         return function (context, callback) {
@@ -544,7 +545,7 @@ var nodes = exports.nodes = {
 
     LoadNode: function (path, package) {
         return function (context, callback) {
-            process.mixin(context.filters, package.filters);
+            mixin(context.filters, package.filters);
             callback(false, '');
         }
     },
@@ -613,7 +614,7 @@ var nodes = exports.nodes = {
 
             var url = string_utils.regex_to_string(match, replacements.map(function (x) { return context.get(x); }));
             if (url[0] !== '/') { url = '/' + url; }
-            
+
             if (item_name) {
                 context.set( item_name, url);
                 callback(false, '');
@@ -638,7 +639,7 @@ var tags = exports.tags = {
     },
 
     'for': function (parser, token) {
-        
+
         var parts = get_args_from_token(token, { exclude: 2, mustbe: { 2: 'in', 4: 'reversed'} });
 
         var itemname = parts[0],
@@ -653,7 +654,7 @@ var tags = exports.tags = {
 
         return nodes.ForNode(node_list, empty_list, itemname, listname, isReversed);
     },
-    
+
     'if': function (parser, token) {
 
         var parts = token.split_contents();
@@ -686,7 +687,7 @@ var tags = exports.tags = {
         }
 
         var node_list, else_list;
-        
+
         node_list = parser.parse('else', 'end' + token.type);
         if (parser.next_token().type === 'else') {
             else_list = parser.parse('end' + token.type);
@@ -700,7 +701,7 @@ var tags = exports.tags = {
         var parts = get_args_from_token(token);
 
         var node_list, else_list;
-        
+
         node_list = parser.parse('else', 'end' + token.type);
         if (parser.next_token().type === 'else') {
             else_list = parser.parse('end' + token.type);
@@ -714,7 +715,7 @@ var tags = exports.tags = {
         var parts = get_args_from_token(token, { argcount: 2 });
 
         var node_list, else_list;
-        
+
         node_list = parser.parse('else', 'end' + token.type);
         if (parser.next_token().type === 'else') {
             else_list = parser.parse('end' + token.type);
@@ -728,7 +729,7 @@ var tags = exports.tags = {
         var parts = get_args_from_token(token, { argcount: 2 });
 
         var node_list, else_list;
-        
+
         node_list = parser.parse('else', 'end' + token.type);
         if (parser.next_token().type === 'else') {
             else_list = parser.parse('end' + token.type);
@@ -787,7 +788,7 @@ var tags = exports.tags = {
         parser.delete_first_token();
         return nodes.AutoescapeNode(node_list, parts[0]);
     },
-    
+
     'block': function (parser, token) {
         var parts = get_args_from_token(token, { argcount: 1 });
         var node_list = parser.parse('end' + token.type);
@@ -805,7 +806,7 @@ var tags = exports.tags = {
         parser.delete_first_token();
         return nodes.WithNode(node_list, parts[0], parts[1], parts[2]);
     },
-    
+
     'now': simple_tag(nodes.NowNode, { argcount: 1 }),
     'include': simple_tag(nodes.IncludeNode, { argcount: 1 }),
     'load': function (parser, token) {
@@ -816,7 +817,7 @@ var tags = exports.tags = {
         }
 
         var package = require(name);
-        process.mixin(parser.tags, package.tags);
+        mixin(parser.tags, package.tags);
 
         return nodes.LoadNode(name, package);
     },

--- a/template/template_defaults.js
+++ b/template/template_defaults.js
@@ -1,7 +1,6 @@
 /*jslint eqeqeq: true, undef: true, regexp: false */
 /*global require, process, exports, escape */
 
-var sys = require('sys');
 var string_utils = require('../utils/string');
 var mixin = require('../utils/mixin').mixin;
 var date_utils = require('../utils/date');

--- a/template/template_defaults.tags.test.js
+++ b/template/template_defaults.tags.test.js
@@ -1,4 +1,3 @@
-var sys = require('sys');
 var fs = require('fs');
 var template = require('./template');
 var mixin = require('../utils/mixin').mixin;

--- a/template/template_defaults.tags.test.js
+++ b/template/template_defaults.tags.test.js
@@ -1,9 +1,10 @@
 var sys = require('sys');
 var fs = require('fs');
 var template = require('./template');
+var mixin = require('../utils/mixin').mixin;
 
-process.mixin(GLOBAL, require('../utils/test').dsl);
-process.mixin(GLOBAL, require('./template_defaults'));
+mixin(GLOBAL, require('../utils/test').dsl);
+mixin(GLOBAL, require('./template_defaults'));
 
 function write_file(path, content) {
     var file = fs.openSync(path, process.O_WRONLY | process.O_TRUNC | process.O_CREAT, 0666);
@@ -67,7 +68,7 @@ testcase('variable')
 
 
 testcase('ifnode')
-    setup(function () { return { obj: {a: true, b: false }}; }); 
+    setup(function () { return { obj: {a: true, b: false }}; });
 
     make_parse_and_execute_test('hest', '{% if a %}hest{% endif %}');
     make_parse_and_execute_test('', '{% if b %}hest{% endif %}');
@@ -84,12 +85,12 @@ testcase('comment')
     make_parse_and_execute_test('', '{% comment %} do not parse {% hest %} any of this{% endcomment %}');
 
 testcase('cycle')
-    setup(function () { return { obj: { c: 'C', items: [1,2,3,4,5,6,7,8,9] }}; }); 
+    setup(function () { return { obj: { c: 'C', items: [1,2,3,4,5,6,7,8,9] }}; });
     make_parse_and_execute_test('a1 b2 C3 a4 b5 C6 a7 b8 C9 ',
         '{% for item in items %}{% cycle \'a\' "b" c %}{{ item }} {% endfor %}');
 
-    make_parse_and_execute_test('a H b J c H a', 
-        '{% cycle "a" "b" "c" as tmp %} {% cycle "H" "J" as tmp2 %} ' + 
+    make_parse_and_execute_test('a H b J c H a',
+        '{% cycle "a" "b" "c" as tmp %} {% cycle "H" "J" as tmp2 %} ' +
         '{% cycle tmp %} {% cycle tmp2 %} {% cycle tmp %} {% cycle tmp2 %} {%cycle tmp %}',
         'should work with as tag'
     );
@@ -106,7 +107,7 @@ testcase('block and extend')
         write_file('/tmp/block_test_1.html', 'Joel is a slug');
         write_file('/tmp/block_test_2.html', 'Her er en dejlig {% block test %}hest{% endblock %}.');
         write_file('/tmp/block_test_3.html',
-            '{% block test1 %}hest{% endblock %}.' 
+            '{% block test1 %}hest{% endblock %}.'
             + '{% block test2 %} noget {% endblock %}'
         );
         write_file('/tmp/block_test_4.html',
@@ -172,7 +173,7 @@ testcase('with')
         var t = template.parse('{% with test.sub.func as tmp %}{{ tmp }}:{{ tmp }}{% endwith %}');
         var cnt = 0;
         var o = { test: { sub: { func: function () { cnt++; return cnt; } } } }
-    
+
         t.render(o, function (error, result) {
             if (error) {
                 fail( error, complete );
@@ -185,7 +186,7 @@ testcase('with')
     });
 
 testcase('ifchanged')
-    setup(function () { return {obj: { list:['hest','giraf','giraf','hestgiraf'] }}; }); 
+    setup(function () { return {obj: { list:['hest','giraf','giraf','hestgiraf'] }}; });
     make_parse_and_execute_test('hestgirafhestgiraf',
         '{% for item in list %}{% ifchanged %}{{ item }}{% endifchanged %}{%endfor%}'
     );
@@ -194,7 +195,7 @@ testcase('ifchanged')
     );
 
 testcase('ifequal')
-    setup(function () { return {obj:{item: 'hest', other: 'hest', fish: 'laks' } }; }); 
+    setup(function () { return {obj:{item: 'hest', other: 'hest', fish: 'laks' } }; });
 
     make_parse_and_execute_test('giraf', '{% ifequal "hest" "hest" %}giraf{%endifequal %}');
     make_parse_and_execute_test('giraf', '{% ifequal item "hest" %}giraf{%endifequal %}');
@@ -203,7 +204,7 @@ testcase('ifequal')
     make_parse_and_execute_test('tapir', '{% ifequal item fish %}giraf{% else %}tapir{%endifequal %}');
 
 testcase('ifnotequal')
-    setup(function () { return {obj:{item: 'hest', other: 'hest', fish: 'laks' } }; }); 
+    setup(function () { return {obj:{item: 'hest', other: 'hest', fish: 'laks' } }; });
 
     make_parse_and_execute_test('laks', '{% ifnotequal "hest" "giraf" %}laks{%endifnotequal %}');
     make_parse_and_execute_test('laks', '{% ifnotequal item "giraf" %}laks{%endifnotequal %}');
@@ -221,7 +222,7 @@ testcase('now')
         t.render({}, function (error, result) {
             if (error) {
                 fail(error, complete);
-            } else { 
+            } else {
                 assertEquals(expected, result, complete);
             }
             end_async_test(complete);
@@ -262,7 +263,7 @@ testcase('spaceless')
         '{% spaceless %}<p>\n        <a href="foo/">Foo</a>\n    </p>{% endspaceless %}');
 
 testcase('widthratio')
-    setup(function () { return {obj:{this_value: 175, max_value: 200 } }; }); 
+    setup(function () { return {obj:{this_value: 175, max_value: 200 } }; });
     make_parse_and_execute_test('88', '{% widthratio this_value max_value 100 %}');
 
 testcase('regroup')
@@ -284,7 +285,7 @@ testcase('regroup')
         '<li>Male:<ul><li>George Bush</li><li>Bill Clinton</li></ul></li>' +
         '<li>Female:<ul><li>Margaret Thatcher</li><li>Condoleezza Rice</li></ul></li>' +
         '<li>Unknown:<ul><li>Pat Smith</li></ul></li></ul>',
-        '{% regroup people by gender as gender_list %}' + 
+        '{% regroup people by gender as gender_list %}' +
         '<ul>{% for gender in gender_list %}<li>{{ gender.grouper }}:' +
         '<ul>{% for item in gender.list %}<li>{{ item.first_name }} {{ item.last_name }}</li>{% endfor %}' +
         '</ul></li>{% endfor %}</ul>');

--- a/template/template_defaults.test.js
+++ b/template/template_defaults.test.js
@@ -1,4 +1,3 @@
-var sys = require('sys');
 var mixin = require('../utils/mixin').mixin;
 
 mixin(GLOBAL, require('../utils/test').dsl);

--- a/template/template_defaults.test.js
+++ b/template/template_defaults.test.js
@@ -1,6 +1,8 @@
 var sys = require('sys');
-process.mixin(GLOBAL, require('../utils/test').dsl);
-process.mixin(GLOBAL, require('./template_defaults'));
+var mixin = require('../utils/mixin').mixin;
+
+mixin(GLOBAL, require('../utils/test').dsl);
+mixin(GLOBAL, require('./template_defaults'));
 
 testcase('add')
     test('should add correctly', function () {
@@ -35,13 +37,13 @@ testcase('date')
     });
 testcase('default')
     test('work as expected', function () {
-        assertEquals(6, filters['default'](false, 6));  
+        assertEquals(6, filters['default'](false, 6));
     })
 testcase('default_if_none')
     test('work as expected', function () {
-        assertEquals(false, filters.default_if_none(false, 6));  
-        assertEquals(6, filters.default_if_none(null, 6));  
-        assertEquals(6, filters.default_if_none(undefined, 6));  
+        assertEquals(false, filters.default_if_none(false, 6));
+        assertEquals(6, filters.default_if_none(null, 6));
+        assertEquals(6, filters.default_if_none(undefined, 6));
     })
 testcase('Test dictsort filter');
     test('should sort correctly', function () {
@@ -243,9 +245,9 @@ testcase('linenumbers')
     });
 testcase('ljust')
     test('should left justify value i correctly sized field', function () {
-        assertEquals('hest      ', filters.ljust('hest', 10)); 
-        assertEquals('', filters.ljust('hest')); 
-        assertEquals('he', filters.ljust('hest', 2)); 
+        assertEquals('hest      ', filters.ljust('hest', 10));
+        assertEquals('', filters.ljust('hest'));
+        assertEquals('he', filters.ljust('hest', 2));
     });
 testcase('lower')
     test('should lowercase value', function () {
@@ -301,9 +303,9 @@ testcase('removetags');
     });
 testcase('rjust')
     test('should right justify value in correctly sized field', function () {
-        assertEquals('      hest', filters.rjust('hest', 10)); 
-        assertEquals('', filters.rjust('hest')); 
-        assertEquals('he', filters.rjust('hest', 2)); 
+        assertEquals('      hest', filters.rjust('hest', 10));
+        assertEquals('', filters.rjust('hest'));
+        assertEquals('he', filters.rjust('hest', 2));
     });
 testcase('slice')
     var arr = [0,1,2,3,4,5,6,7,8,9];

--- a/template_example.js
+++ b/template_example.js
@@ -1,4 +1,4 @@
-var sys = require('sys'),
+var util = require('util'),
     dj = require('./djangode'),
     template_system = require('./template/template');
     template_loader = require('./template/loader');
@@ -39,7 +39,7 @@ var app = dj.makeApp([
     }],
 
     ['^/context$', function (req, res) {
-        dj.respond(res, sys.inspect(test_context), 'text/plain');
+        dj.respond(res, util.inspect(test_context), 'text/plain');
     }],
 
     ['^/text$', function (req, res) {

--- a/utils/date.js
+++ b/utils/date.js
@@ -1,5 +1,3 @@
-var sys = require('sys');
-
 // Internationalization strings
 var i18n = {
     'en-us': {

--- a/utils/date.test.js
+++ b/utils/date.test.js
@@ -1,8 +1,6 @@
 var mixin = require('../mixin').mixin;
 mixin(GLOBAL, require('./test').dsl);
 mixin(GLOBAL, require('./date'));
-var sys = require('sys');
-
 
 testcase('date_format')
     test('should format each filter correctly', function () {

--- a/utils/date.test.js
+++ b/utils/date.test.js
@@ -1,5 +1,6 @@
-process.mixin(GLOBAL, require('./test').dsl);
-process.mixin(GLOBAL, require('./date'));
+var mixin = require('../mixin').mixin;
+mixin(GLOBAL, require('./test').dsl);
+mixin(GLOBAL, require('./date'));
 var sys = require('sys');
 
 
@@ -78,7 +79,7 @@ testcase('timesince');
 
         date = new Date("Wed Nov 13 1980 10:36:13 GMT+0100 (CET)");
         assertEquals('1 year', timesince(date, now));
-        
+
         date = new Date("Wed Dec 02 1981 18:29:40 GMT+0100 (CET)"); // Random time on Britney Spears birthday :-)
         assertEquals('2 minutes', timesince(date, now));
 

--- a/utils/html.js
+++ b/utils/html.js
@@ -1,8 +1,6 @@
 /*jslint laxbreak: true, eqeqeq: true, undef: true, regexp: false */
 /*global require, process, exports */
 
-var sys = require('sys');
-
 /*  Function: escape(value);
         Escapes the characters &, <, >, ' and " in string with html entities.
     Arguments:

--- a/utils/html.test.js
+++ b/utils/html.test.js
@@ -1,5 +1,6 @@
-process.mixin(GLOBAL, require('./test').dsl);
-process.mixin(GLOBAL, require('./html'));
+var mixin = require('./mixin').mixin;
+mixin(GLOBAL, require('./test').dsl);
+mixin(GLOBAL, require('./html'));
 
 testcase('tests for linebreaks()')
     test('should break lines into <p> and <br /> tags', function () {

--- a/utils/iter.js
+++ b/utils/iter.js
@@ -1,5 +1,3 @@
-var sys = require('sys');
-
 exports.reduce = function reduce(array, iter_callback, initial, result_callback) {
 
     var index = 0;

--- a/utils/iter.test.js
+++ b/utils/iter.test.js
@@ -1,5 +1,6 @@
-process.mixin(GLOBAL, require('./test').dsl);
-process.mixin(GLOBAL, require('./iter'));
+var mixin = require('./mixin').mixin;
+mixin(GLOBAL, require('./test').dsl);
+mixin(GLOBAL, require('./iter'));
 
 var events = require('events');
 var sys = require('sys');

--- a/utils/iter.test.js
+++ b/utils/iter.test.js
@@ -3,7 +3,6 @@ mixin(GLOBAL, require('./test').dsl);
 mixin(GLOBAL, require('./iter'));
 
 var events = require('events');
-var sys = require('sys');
 
 testcase('reduce');
     test_async('should work like regular reduce', function (content, callback) {
@@ -15,11 +14,9 @@ testcase('reduce');
 
         //var t = new Date();
         var expected = list.reduce(function (p, c) { return p + c; }, 0);
-        //sys.debug(new Date() - t);
 
         reduce(list, function (p, c, idx, list, callback) { callback(false, p + c); }, 0,
             function (error, actual) {
-                //sys.debug(new Date() - t);
                 assertEquals(expected, actual, callback);
                 callback();
             }

--- a/utils/mixin.js
+++ b/utils/mixin.js
@@ -1,0 +1,9 @@
+function mixin(to, from) {
+    for (var key in from) {
+        if (from.hasOwnProperty(key)) {
+            to[key] = from[key];
+        }
+    }
+}
+
+exports.mixin = mixin;

--- a/utils/string.js
+++ b/utils/string.js
@@ -1,8 +1,6 @@
 /*jslint laxbreak: true, eqeqeq: true, undef: true, regexp: false */
 /*global require, process, exports */
 
-var sys = require('sys');
-
 /* Function: smart_split(s)
  *      Split a string by spaces, leaving qouted phrases together. Supports both
  *      single and double qoutes, and supports escaping strings qoutes with

--- a/utils/string.test.js
+++ b/utils/string.test.js
@@ -1,4 +1,3 @@
-var sys = require('sys');
 var mixin = require('./mixin').mixin;
 
 mixin(GLOBAL, require('./test').dsl);

--- a/utils/string.test.js
+++ b/utils/string.test.js
@@ -1,7 +1,8 @@
 var sys = require('sys');
+var mixin = require('./mixin').mixin;
 
-process.mixin(GLOBAL, require('./test').dsl);
-process.mixin(GLOBAL, require('./string'));
+mixin(GLOBAL, require('./test').dsl);
+mixin(GLOBAL, require('./string'));
 
 testcase('string utility functions');
     test('smart_split should split correctly', function () {
@@ -38,7 +39,7 @@ testcase('regex_to_string')
         assertEquals('hest*', regex_to_string(/hest\*/));
         assertEquals('hestgiraf', regex_to_string(/hest(tobis)giraf/));
     });
-    
+
     test('should replace groups with input', function () {
         assertEquals('shows/hest/34/', regex_to_string(/^shows\/(\w+)\/(\d+)\/$/, ['hest', 34]));
         assertEquals('shows/giraf/90/', regex_to_string(/^shows\/(hest(?:laks|makrel))\/(\d+)\/$/, ['giraf', 90]));

--- a/utils/test.js
+++ b/utils/test.js
@@ -1,6 +1,6 @@
 /*jslint laxbreak: true, eqeqeq: true, undef: true, regexp: false */
 /*global require, process, exports */
-var sys = require('sys');
+var util = require('util');
 
 var AssertFailedException = function (msg) {
     this.message = msg;
@@ -90,7 +90,7 @@ exports.dsl = {
             var testcase = testcases[testcase_idx--];
 
             if (testcase) {
-                sys.puts('\n[Testcase: ' + testcase.name + ']');
+                util.puts('\n[Testcase: ' + testcase.name + ']');
 
                 (function run_tests() {
 
@@ -110,25 +110,25 @@ exports.dsl = {
                                 async_test_has_failed = true;
 
                                 if (error instanceof AssertFailedException) {
-                                    sys.puts(' [--] ' + test.name + ': failed. ' + error.message);
+                                    util.puts(' [--] ' + test.name + ': failed. ' + error.message);
                                     failed_cnt++;
                                 } else {
-                                    sys.print(' [!!] ' + test.name + ': error. ');
+                                    util.print(' [!!] ' + test.name + ': error. ');
                                     if (error.stack && error.type) {
-                                        sys.puts(error.type + '\n' +  error.stack);
+                                        util.puts(error.type + '\n' +  error.stack);
                                     } else {
-                                        sys.puts(JSON.stringify(error, 0, 2));
+                                        util.puts(JSON.stringify(error, 0, 2));
                                     }
                                     error_cnt++;
                                 }
 
                                 if (stop_on_error) {
-                                    sys.puts('stopping on first error');
+                                    util.puts('stopping on first error');
                                     testcase_idx = -1;
                                     idx = testcase.tests.length;
                                 }
                             } else {
-                                sys.puts(' [OK] ' + test.name + ': passed');
+                                util.puts(' [OK] ' + test.name + ': passed');
                             }
 
                             if (testcase.teardown) { testcase.teardown(context); }
@@ -144,13 +144,13 @@ exports.dsl = {
 
                     } else {
                         // no more tests
-                        sys.puts('----');
+                        util.puts('----');
                         process.nextTick(run_testcases);
                     }
                 })();
             } else {
                 // no more testcases
-                sys.puts('\nTotal: ' + count + ', Failures: ' + failed_cnt + ', Errors: ' + error_cnt + '');
+                util.puts('\nTotal: ' + count + ', Failures: ' + failed_cnt + ', Errors: ' + error_cnt + '');
             }
 
         })();
@@ -160,7 +160,7 @@ exports.dsl = {
         if (async_test_has_failed) { return; }
         if (!isEqual(actual, expected)) {
             var exception = new AssertFailedException(
-                '\nExpected: ' + sys.inspect(actual) + '\nActual: ' + sys.inspect(expected) + '\n'
+                '\nExpected: ' + util.inspect(actual) + '\nActual: ' + util.inspect(expected) + '\n'
             ); 
             if (callback) { callback(exception); } else { throw exception; }
         };
@@ -169,7 +169,7 @@ exports.dsl = {
     assertIsTrue: function (actual, callback) {
         if (async_test_has_failed) { return; }
         if (!actual) {
-            var exception = new AssertFailedException('\nExpected ' + sys.inspect(actual) + ' to be true\n'); 
+            var exception = new AssertFailedException('\nExpected ' + util.inspect(actual) + ' to be true\n'); 
             if (callback) { callback(exception); } else { throw exception; }
         }
     },
@@ -177,7 +177,7 @@ exports.dsl = {
     assertIsFalse: function (actual, callback) {
         if (async_test_has_failed) { return; }
         if (actual) {
-            var exception = new AssertFailedException('\nExpected ' + sys.inspect(actual) + ' to be false\n'); 
+            var exception = new AssertFailedException('\nExpected ' + util.inspect(actual) + ' to be false\n'); 
             if (callback) { callback(exception); } else { throw exception; }
         }
     },


### PR DESCRIPTION
Remove use of deprecated process.mixin, replace with util/mixin.js:mixin()

process.mixin seems to be entirely gone in Node.js 0.5.5.
